### PR TITLE
LCAクラスの修正とCIワークフロー改善

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -3,7 +3,7 @@ on:
   push:
   pull_request:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 jobs:
   rspec:

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -1,6 +1,7 @@
 name: Ruby CI
 on:
   push:
+    branches: [main]
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -1,20 +1,19 @@
 name: Ruby CI
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   rspec:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.4
-    - name: Install dependencies
-      run: |
-        bundle
+        ruby-version: .ruby-version
+        bundler-cache: true
     - name: Run rspec
-      run: bundle exec rspec ./ruby/spec
+      run: bundle exec rspec ./ruby/spec --format documentation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-25
+  x86_64-linux
 
 DEPENDENCIES
   ac-library-rb

--- a/ruby/lib/lca.rb
+++ b/ruby/lib/lca.rb
@@ -1,36 +1,73 @@
+# ダブリング（バイナリリフティング）による木の最小共通祖先 (LCA: Lowest Common Ancestor)
+#
+# @example
+#   lca = LCA.new(7, 0)
+#   lca.add_edge(0, 1)
+#   lca.add_edge(0, 2)
+#   lca.add_edge(1, 3)
+#   lca.add_edge(1, 4)
+#   lca.add_edge(2, 5)
+#   lca.add_edge(2, 6)
+#   lca.build
+#   lca.get(3, 4) #=> 1
+#   lca.get(3, 6) #=> 0
+#   lca.get(5, 5) #=> 5
+#
+# @note 入力は連結な木であることを前提とする。{#build} 前に {#get} を呼ぶと例外。
+# @note 計算量: 前処理 O(N log N) / クエリ O(log N) / 空間 O(N log N)
 class LCA
-  attr_reader :parents, :depth, :orders, :edges, :bit, :size
+  # @return [Array<Array<Integer>>] +parents[k][v]+ で頂点 v の 2^k 個上の祖先
+  # @return [Array<Integer>] 各頂点の根からの深さ
+  # @return [Array<Integer>] 各頂点の DFS 行きがけ順 (preorder, 0-origin)
+  # @return [Array<Array<Integer>>] 隣接リスト
+  # @return [Integer] ダブリングの段数 (= +n.bit_length+)
+  # @return [Integer] 頂点数
+  # @return [Integer] 根の頂点番号
+  attr_reader :parents, :depth, :orders, :edges, :bit, :size, :root
 
-  def initialize(n)
+  # @param n [Integer] 頂点数
+  # @param root [Integer] 根とする頂点番号 (0-origin)
+  def initialize(n, root)
     @size = n
+    @root = root
     @bit = n.bit_length
-    @parents = Array.new(bit) { Array.new(n) }
-    @depth = Array.new(n, -1)
-    @depth[0] = 0
+    @parents = Array.new(bit) { [0] * n }
+    @depth = [0] * n
     @orders = Array.new(n)
     @edges = Array.new(n) { [] }
-    @current_order = 0
+    @built = false
   end
 
+  # 無向辺を追加する
+  # @param u [Integer] 端点の頂点番号
+  # @param v [Integer] 端点の頂点番号
+  # @return [void]
+  # @note 呼び出すと {#built?} は false に戻り、再度 {#build} が必要となる
   def add_edge(u, v)
+    @built = false
     edges[u] << v
     edges[v] << u
   end
 
+  # ダブリングテーブルを構築する。{#get} を呼ぶ前に必ず実行すること
+  # @return [void]
+  # @note 計算量: O(N log N)
   def build
+    @built = true
     current_order = 0
-    dfs = -> (pos = 0, pre = 0) do
+    # [pos, pre]
+    stack = [[root, root]]
+    until stack.empty?
+      pos, pre = stack.pop
       parents[0][pos] = pre
       orders[pos] = current_order
       current_order += 1
       edges[pos].each do |to|
         next if to == pre
         depth[to] = depth[pos] + 1
-        dfs.(to, pos)
+        stack << [to, pos]
       end
     end
-
-    dfs.()
 
     (bit - 1).times do |i|
       size.times do |j|
@@ -39,7 +76,15 @@ class LCA
     end
   end
 
+  # 2 頂点の最小共通祖先を返す
+  # @param u [Integer] 頂点番号
+  # @param v [Integer] 頂点番号
+  # @return [Integer] u と v の最小共通祖先の頂点番号
+  # @raise [RuntimeError] {#build} 未実行の場合
+  # @note 計算量: O(log N)
   def get(u, v)
+    raise "buildされていません。" unless built?
+
     u, v = v, u if depth[u] < depth[v]
     diff = depth[u] - depth[v]
     bit.times do |i|
@@ -55,4 +100,9 @@ class LCA
     end
     parents[0][u]
   end
+
+  private
+
+  # @return [Boolean] {#build} 済みかどうか
+  def built? = @built
 end

--- a/ruby/spec/lca_spec.rb
+++ b/ruby/spec/lca_spec.rb
@@ -1,0 +1,206 @@
+require_relative "../lib/lca"
+
+# LCA（最小共通祖先）のテスト
+RSpec.describe LCA do
+  describe "#initialize" do
+    let(:lca) { LCA.new(5, 0) }
+
+    it "頂点数が設定されること" do
+      expect(lca.size).to eq 5
+    end
+
+    it "根が設定されること" do
+      expect(lca.root).to eq 0
+    end
+
+    it "ダブリングの段数が n.bit_length であること" do
+      expect(lca.bit).to eq 5.bit_length
+    end
+
+    it "辺が空であること" do
+      expect(lca.edges).to eq Array.new(5) { [] }
+    end
+  end
+
+  describe "#add_edge" do
+    let(:lca) { LCA.new(3, 0) }
+
+    it "両方向に辺が追加されること" do
+      lca.add_edge(0, 1)
+      expect(lca.edges[0]).to eq [1]
+      expect(lca.edges[1]).to eq [0]
+    end
+  end
+
+  describe "#build" do
+    #     0
+    #    / \
+    #   1   2
+    #  / \
+    # 3   4
+    let(:lca) {
+      lca = LCA.new(5, 0)
+      lca.add_edge(0, 1)
+      lca.add_edge(0, 2)
+      lca.add_edge(1, 3)
+      lca.add_edge(1, 4)
+      lca.build
+      lca
+    }
+
+    it "各頂点の深さが正しく計算されること" do
+      expect(lca.depth).to eq [0, 1, 1, 2, 2]
+    end
+
+    it "各頂点の親 (parents[0]) が正しく設定されること" do
+      # 根の親は自分自身
+      expect(lca.parents[0][0]).to eq 0
+      expect(lca.parents[0][1]).to eq 0
+      expect(lca.parents[0][2]).to eq 0
+      expect(lca.parents[0][3]).to eq 1
+      expect(lca.parents[0][4]).to eq 1
+    end
+
+    it "ダブリングテーブルが正しく構築されること" do
+      # 2 個上の祖先 (parents[1]): いずれも根 (= 0)
+      5.times { |v| expect(lca.parents[1][v]).to eq 0 }
+    end
+  end
+
+  describe "#get" do
+    context "ビルド前に呼ばれた場合" do
+      let(:lca) { LCA.new(3, 0) }
+
+      it "例外が発生すること" do
+        lca.add_edge(0, 1)
+        lca.add_edge(0, 2)
+        expect { lca.get(1, 2) }.to raise_error(RuntimeError, /buildされていません/)
+      end
+    end
+
+    context "二分木の場合" do
+      #         0
+      #       /   \
+      #      1     2
+      #     / \   / \
+      #    3   4 5   6
+      let(:lca) {
+        lca = LCA.new(7, 0)
+        [[0, 1], [0, 2], [1, 3], [1, 4], [2, 5], [2, 6]].each { lca.add_edge(*_1) }
+        lca.build
+        lca
+      }
+
+      it "兄弟ノードのLCAが親であること" do
+        expect(lca.get(3, 4)).to eq 1
+        expect(lca.get(5, 6)).to eq 2
+      end
+
+      it "異なる部分木のノードのLCAが根であること" do
+        expect(lca.get(3, 6)).to eq 0
+        expect(lca.get(4, 5)).to eq 0
+      end
+
+      it "祖先と子孫の関係ではLCAが祖先側であること" do
+        expect(lca.get(1, 3)).to eq 1
+        expect(lca.get(0, 6)).to eq 0
+      end
+
+      it "同じ頂点を指定した場合はその頂点を返すこと" do
+        expect(lca.get(3, 3)).to eq 3
+        expect(lca.get(0, 0)).to eq 0
+      end
+
+      it "頂点の順序を入れ替えても結果が同じであること" do
+        expect(lca.get(3, 6)).to eq lca.get(6, 3)
+        expect(lca.get(1, 5)).to eq lca.get(5, 1)
+      end
+    end
+
+    context "パスグラフ (鎖) の場合" do
+      # 0 - 1 - 2 - 3 - 4
+      let(:lca) {
+        lca = LCA.new(5, 0)
+        4.times { |i| lca.add_edge(i, i + 1) }
+        lca.build
+        lca
+      }
+
+      it "深さが連続していること" do
+        expect(lca.depth).to eq [0, 1, 2, 3, 4]
+      end
+
+      it "浅い側の頂点がLCAであること" do
+        expect(lca.get(2, 4)).to eq 2
+        expect(lca.get(0, 4)).to eq 0
+        expect(lca.get(1, 3)).to eq 1
+      end
+    end
+
+    context "根が 0 でない場合" do
+      #         3
+      #       /   \
+      #      1     2
+      #     /
+      #    0
+      let(:lca) {
+        lca = LCA.new(4, 3)
+        [[3, 1], [3, 2], [1, 0]].each { lca.add_edge(*_1) }
+        lca.build
+        lca
+      }
+
+      it "指定した頂点が根として扱われること" do
+        expect(lca.depth[3]).to eq 0
+        expect(lca.parents[0][3]).to eq 3
+      end
+
+      it "LCAが正しく求まること" do
+        expect(lca.get(0, 2)).to eq 3
+        expect(lca.get(0, 1)).to eq 1
+      end
+    end
+
+    context "深い木の場合 (再帰スタックオーバーフロー回避の確認)" do
+      # 0 - 1 - 2 - ... - (n-1) の長いパス
+      let(:n) { 20_000 }
+      let(:lca) {
+        lca = LCA.new(n, 0)
+        (n - 1).times { |i| lca.add_edge(i, i + 1) }
+        lca.build
+        lca
+      }
+
+      it "深い木でも build できること" do
+        expect(lca.depth.last).to eq n - 1
+      end
+
+      it "深い木でも LCA を求められること" do
+        expect(lca.get(n - 1, n / 2)).to eq n / 2
+        expect(lca.get(0, n - 1)).to eq 0
+      end
+    end
+  end
+
+  describe "build と add_edge の連携" do
+    let(:lca) {
+      lca = LCA.new(4, 0)
+      lca.add_edge(0, 1)
+      lca.add_edge(1, 2)
+      lca.build
+      lca
+    }
+
+    it "build 後に add_edge すると get が例外を投げること" do
+      lca.add_edge(2, 3)
+      expect { lca.get(0, 3) }.to raise_error(RuntimeError, /buildされていません/)
+    end
+
+    it "再 build すれば get が再び使えること" do
+      lca.add_edge(2, 3)
+      lca.build
+      expect(lca.get(0, 3)).to eq 0
+      expect(lca.get(2, 3)).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- **LCAクラスの修正**: `get` 内の `builded` 参照によるNoMethodErrorを修正、再帰DFSを反復化してスタックオーバーフロー耐性を獲得、root引数の追加と状態管理（`@built`）の改善
- **YARDocとspecテストを追加**: 全public APIにドキュメント、22ケースのspecで二分木・パスグラフ・深い木（20,000ノード）・root != 0 などを網羅
- **CIワークフローを改善**: 全ブランチで実行、`.ruby-version` 参照、bundler-cache、進行中CIの自動キャンセル、actions/checkout v6

## 変更の背景
LCAクラスは `get` を一度も呼ばずにマージされており、コードレビューで `builded` メソッドが存在しないことによるNoMethodErrorが発覚。あわせて再帰DFSのスタック耐性問題、状態管理の脆弱性、ドキュメント・テストの欠如を解決する。

## Test plan
- [x] ローカルで `bundle exec rspec ./ruby/spec` が全件pass（267 examples, 0 failures）
- [x] LCA spec 22ケースが全てpass
- [x] 20,000ノードのパスグラフで `build` がスタックオーバーフローしないことを確認
- [ ] GitHub ActionsでCIがpassすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)